### PR TITLE
Fixing image upload example in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ M.get('timelines/home', {}).then(resp => console.log(resp.data))
 ### Upload an image and attach it to a tweet
 ```javascript
 var id;
-M.post('media', { file: fs.createReadStream('path/to/image.png') }).then(resp => id = resp.data.id)
-M.post('statuses', { status: '#selfie', media_ids: [id] });
+M.post('media', { file: fs.createReadStream('path/to/image.png') }).then(resp => {
+  id = resp.data.id;
+  M.post('statuses', { status: '#selfie', media_ids: [id] })
+})
 ```
 
 -------


### PR DESCRIPTION
The example threw errors because it wasn't actually running nested POSTs. This corrects the order of operations.