### PR TITLE
catch errors in _doRestApiRequest

### DIFF
--- a/lib/mastodon.js
+++ b/lib/mastodon.js
@@ -78,6 +78,10 @@ Mastodon.prototype.request = function (method, path, params, callback) {
       process.nextTick(function () {
         // ensure all HTTP i/o occurs after the user has a chance to bind their event handlers
         self._doRestApiRequest(reqOpts, mastoOptions, method, function (err, parsedBody, resp) {
+          if (err) {
+            _returnErrorToUser(err);
+            return
+          }
           self._updateClockOffsetFromResponse(resp);
 
           if (self.config.trusted_cert_fingerprints) {


### PR DESCRIPTION
Fixes an issue where a request can fail (eg. network error) but not reject the promise.