### PR TITLE
Fixes to REST API requests

### DIFF
--- a/lib/mastodon.js
+++ b/lib/mastodon.js
@@ -161,7 +161,8 @@ Mastodon.prototype._buildReqOpts = function (method, path, params, callback) {
 
   try {
     // finalize the `path` value by building it using user-supplied params
-    path = helpers.moveParamsIntoPath(finalParams, path)
+    if (method === 'GET')
+      path = helpers.moveParamsIntoPath(finalParams, path)
   } catch (e) {
     callback(e, null, null)
     return
@@ -182,7 +183,10 @@ Mastodon.prototype._buildReqOpts = function (method, path, params, callback) {
   } else {
     // Non-file-upload params should be url-encoded
     if (Object.keys(finalParams).length > 0) {
-      reqOpts.url += this.formEncodeParams(finalParams);
+      if (request === 'GET')
+        reqOpts.url += this.formEncodeParams(finalParams);
+      else
+        reqOpts.body = this.formEncodeParams(finalParams).replace(/^\?/, '');
     }
   }
 
@@ -214,7 +218,8 @@ Mastodon.prototype._doRestApiRequest = function (reqOpts, mastoOptions, method, 
         // surface this to the caller
         var err = helpers.makeMastodonError('JSON decode error: Mastodon HTTP response body was not valid JSON')
         err.statusCode = response ? response.statusCode: null;
-        err.allErrors.concat({error: jsonDecodeError.toString()})
+        err.allErrors.push({error: jsonDecodeError.toString()});
+        err.mastodonReply = body;
         callback(err, body, response);
         return
       }

--- a/lib/mastodon.js
+++ b/lib/mastodon.js
@@ -161,8 +161,7 @@ Mastodon.prototype._buildReqOpts = function (method, path, params, callback) {
 
   try {
     // finalize the `path` value by building it using user-supplied params
-    if (method === 'GET')
-      path = helpers.moveParamsIntoPath(finalParams, path)
+    path = helpers.moveParamsIntoPath(finalParams, path)
   } catch (e) {
     callback(e, null, null)
     return


### PR DESCRIPTION
* _doRestApiRequest: Push request errors onto err.allErrors
* _doRestApiRequest: Attach full mastodonReply to err.mastodonReply to aid debugging
* _buildReqOpts: for a POST request, put the encoded parameters into request.body instead of the request URL